### PR TITLE
Add EODHD streaming client with resilient subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,81 @@
-Montar un WebSocket con el API de Capital.com. Para recoger 24 en tiempo real toda las operaciones de AVGO AMD y NVDA. 
+# WebSocket Streamers
 
-In 
+Este repositorio contiene dos clientes WebSocket preparados para ejecutar 24/7
+y persistir datos en PostgreSQL con reconexión automática, validaciones y
+logging JSON detallado.
+
+## Requisitos comunes
+
+* Python 3.10+
+* Dependencias Python indicadas en `requirements.txt`
+* Base de datos PostgreSQL 16 accesible con las tablas necesarias
+* Archivo `.env` en la raíz del proyecto para la configuración
+
+Instalar dependencias una sola vez:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Capital.com (`streaming_capital.py`)
+
+Variables obligatorias en `.env`:
+
+```
+CAPITAL_API_KEY=tu_api_key
+CAPITAL_EMAIL=tu_usuario
+CAPITAL_PASSWORD=tu_password
+PGHOST=localhost
+PGPORT=5432
+PGDATABASE=tu_bd
+PGUSER=tu_usuario
+PGPASSWORD=tu_password
+CAPITAL_TARGET_EPICS=AVGO,AMD,NVDA
+CAPITAL_STREAM_TABLE=capital_market_quotes
+CAPITAL_PING_INTERVAL=300
+CAPITAL_RECONNECT_DELAY=5
+```
+
+La tabla `capital_market_quotes` se crea automáticamente con la estructura
+esperada. Ejecuta el servicio con:
+
+```bash
+python streaming_capital.py
+```
+
+## EOD Historical Data (`streaming_eodhd.py`)
+
+Variables obligatorias en `.env`:
+
+```
+API_TOKEN=tu_token_de_eodhd
+SYMBOLS=AVGO:AVGO:11,AMD:AMD:7,NVDA:NVDA:6
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=tu_bd
+DB_USER=tu_usuario
+DB_PASSWORD=tu_password
+```
+
+Cada entrada en `SYMBOLS` sigue el formato `LOCAL:REMOTE:ASSET_ID`. Si el
+símbolo remoto no incluye mercado (por ejemplo `AVGO`), el cliente añadirá el
+sufijo configurado en `EOD_SYMBOL_SUFFIX` (por defecto `.US`) antes de
+suscribirse, lo que evita respuestas 403 de la API. Ajusta opcionalmente:
+
+```
+RECONNECT_DELAY=5              # segundos antes de reintentar
+WS_HEARTBEAT_SECONDS=120       # ping automático del cliente aiohttp
+EOD_SYMBOL_SUFFIX=.US          # sufijo por defecto para símbolos sin mercado
+DB_POOL_MAX=10                 # conexiones máximas del pool PostgreSQL
+```
+
+Previo a insertar trades o quotes, el cliente valida las claves críticas y
+persiste los datos en las tablas `trades_real_time` y `quotes_real_time` (se
+crean automáticamente si no existen). Ejecuta el colector con:
+
+```bash
+python streaming_eodhd.py
+```
+
+Ambos procesos muestran logs estructurados, detectan respuestas de error del
+servidor y se reconectan cada 5 segundos cuando la sesión cae.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+requests
+websocket-client
+psycopg2-binary
+aiohttp
+websockets
+python-dotenv

--- a/streaming_capital.py
+++ b/streaming_capital.py
@@ -1,0 +1,445 @@
+"""
+Capital.com streaming client for capturing AVGO, AMD and NVDA trades via WebSocket
+and persisting them into PostgreSQL.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import threading
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+import psycopg2
+import requests
+from psycopg2.extras import RealDictCursor
+
+try:
+    from websocket import WebSocketApp
+except ImportError as exc:  # pragma: no cover - dependency runtime check
+    raise ImportError(
+        "The 'websocket-client' package is required to run this module"
+    ) from exc
+
+CAPITAL_API_BASE = "https://api-capital.backend-capital.com/api/v1"
+CAPITAL_STREAM_URL = "wss://api-streaming-capital.backend-capital.com/connect"
+
+
+def load_dotenv(env_path: Path) -> None:
+    """Simple .env loader that respects existing environment variables."""
+
+    if not env_path.exists():
+        return
+
+    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if key and key not in os.environ:
+            os.environ[key] = value.strip()
+
+
+@dataclass
+class Config:
+    api_key: str
+    email: str
+    password: str
+    db_host: str
+    db_port: int
+    db_name: str
+    db_user: str
+    db_password: str
+    target_epics: List[str]
+    table_name: str = "capital_market_quotes"
+    ping_interval_seconds: int = 300
+    reconnect_delay_seconds: int = 5
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        raw_epics = os.environ.get("CAPITAL_TARGET_EPICS", "AVGO,AMD,NVDA")
+        epics = [item.strip() for item in raw_epics.split(",") if item.strip()]
+
+        missing = [
+            key
+            for key in ("CAPITAL_API_KEY", "CAPITAL_EMAIL", "CAPITAL_PASSWORD")
+            if not os.environ.get(key)
+        ]
+        if missing:
+            raise RuntimeError(f"Missing Capital.com credentials in environment: {', '.join(missing)}")
+
+        db_missing = [
+            key
+            for key in ("PGHOST", "PGPORT", "PGDATABASE", "PGUSER", "PGPASSWORD")
+            if not os.environ.get(key)
+        ]
+        if db_missing:
+            raise RuntimeError(f"Missing PostgreSQL configuration in environment: {', '.join(db_missing)}")
+
+        cfg = cls(
+            api_key=os.environ["CAPITAL_API_KEY"].strip(),
+            email=os.environ["CAPITAL_EMAIL"].strip(),
+            password=os.environ["CAPITAL_PASSWORD"].strip(),
+            db_host=os.environ["PGHOST"].strip(),
+            db_port=int(os.environ["PGPORT"].strip()),
+            db_name=os.environ["PGDATABASE"].strip(),
+            db_user=os.environ["PGUSER"].strip(),
+            db_password=os.environ["PGPASSWORD"].strip(),
+            target_epics=epics,
+            table_name=os.environ.get("CAPITAL_STREAM_TABLE", "capital_market_quotes"),
+            ping_interval_seconds=int(os.environ.get("CAPITAL_PING_INTERVAL", "300")),
+            reconnect_delay_seconds=int(os.environ.get("CAPITAL_RECONNECT_DELAY", "5")),
+        )
+
+        if not cfg.target_epics:
+            raise RuntimeError("No EPICs configured to subscribe")
+
+        return cfg
+
+
+class CapitalWebSocketStreamer:
+    def __init__(self, config: Config) -> None:
+        self.config = config
+        self.logger = logging.getLogger(self.__class__.__name__)
+        self.stop_event = threading.Event()
+        self.connected_event = threading.Event()
+        self.ws_lock = threading.Lock()
+        self.ws_app: Optional[WebSocketApp] = None
+        self.db_conn = self._create_db_connection()
+        self.asset_ids = self._load_asset_ids()
+        self.tokens: Optional[Dict[str, str]] = None
+        self.ping_thread = threading.Thread(target=self._ping_loop, daemon=True)
+        self.ping_thread.start()
+
+    def _create_db_connection(self) -> psycopg2.extensions.connection:
+        self.logger.info("Connecting to PostgreSQL %s:%s", self.config.db_host, self.config.db_port)
+        conn = psycopg2.connect(
+            host=self.config.db_host,
+            port=self.config.db_port,
+            dbname=self.config.db_name,
+            user=self.config.db_user,
+            password=self.config.db_password,
+        )
+        conn.autocommit = True
+        self._ensure_destination_table(conn)
+        return conn
+
+    def _ensure_destination_table(self, conn: psycopg2.extensions.connection) -> None:
+        create_sql = f"""
+        CREATE TABLE IF NOT EXISTS {self.config.table_name} (
+            id BIGSERIAL PRIMARY KEY,
+            asset_id INTEGER NOT NULL,
+            timestamp TIMESTAMPTZ NOT NULL,
+            symbol TEXT NOT NULL,
+            tipo TEXT NOT NULL,
+            precio_compra DOUBLE PRECISION,
+            cantidad_disponible_compra DOUBLE PRECISION,
+            precio_venta DOUBLE PRECISION,
+            cantidad_disponible_venta DOUBLE PRECISION,
+            epoch BIGINT NOT NULL,
+            inserted_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        """
+        with conn.cursor() as cur:
+            cur.execute(create_sql)
+        self.logger.info("Ensured destination table '%s' exists", self.config.table_name)
+
+    def _load_asset_ids(self) -> Dict[str, int]:
+        self.logger.info("Loading asset ids for EPICs: %s", ", ".join(self.config.target_epics))
+        mapping: Dict[str, int] = {}
+        with self.db_conn.cursor(cursor_factory=RealDictCursor) as cur:
+            cur.execute(
+                "SELECT epic, asset_id FROM assets WHERE epic = ANY(%s)",
+                (self.config.target_epics,),
+            )
+            for row in cur.fetchall():
+                epic = str(row["epic"]).strip()
+                mapping[epic] = int(row["asset_id"])
+        missing = sorted(set(self.config.target_epics) - set(mapping))
+        if missing:
+            raise RuntimeError(
+                "Missing asset_id mappings for EPICs in assets table: " + ", ".join(missing)
+            )
+        self.logger.info("Loaded asset ids for %d EPICs", len(mapping))
+        return mapping
+
+    def authenticate(self) -> None:
+        self.logger.info("Authenticating against Capital.com API")
+        session = requests.Session()
+        session.headers.update({
+            "X-CAP-API-KEY": self.config.api_key,
+            "Content-Type": "application/json",
+        })
+        try:
+            response = session.post(
+                f"{CAPITAL_API_BASE}/session",
+                data=json.dumps({"identifier": self.config.email, "password": self.config.password}),
+                timeout=30,
+            )
+        finally:
+            session.close()
+        if response.status_code not in (200, 201):
+            raise RuntimeError(
+                f"Authentication failed with status {response.status_code}: {response.text[:200]}"
+            )
+        cst = response.headers.get("CST") or response.headers.get("cst")
+        security_token = response.headers.get("X-SECURITY-TOKEN") or response.headers.get("x-security-token")
+        if not cst or not security_token:
+            body = {}
+            try:
+                body = response.json()
+            except Exception:  # pragma: no cover - defensive logging
+                pass
+            cst = cst or body.get("CST")
+            security_token = security_token or body.get("securityToken")
+        if not cst or not security_token:
+            raise RuntimeError("Authentication succeeded but tokens were not received")
+        self.tokens = {"cst": cst, "securityToken": security_token}
+        self.logger.info("Authentication successful, tokens acquired")
+
+    def run(self) -> None:
+        self.logger.info("Starting streaming loop")
+        while not self.stop_event.is_set():
+            try:
+                self.authenticate()
+                self._run_websocket()
+            except Exception as exc:
+                if self.stop_event.is_set():
+                    break
+                self.logger.exception("Error in streaming loop: %s", exc)
+                time.sleep(self.config.reconnect_delay_seconds)
+        self.logger.info("Streaming loop stopped")
+
+    def _run_websocket(self) -> None:
+        headers = []
+        if self.tokens:
+            headers = [f"CST: {self.tokens['cst']}", f"X-SECURITY-TOKEN: {self.tokens['securityToken']}"]
+        self.logger.info("Connecting to WebSocket stream")
+        ws_app = WebSocketApp(
+            CAPITAL_STREAM_URL,
+            header=headers,
+            on_open=self._on_open,
+            on_message=self._on_message,
+            on_close=self._on_close,
+            on_error=self._on_error,
+        )
+        with self.ws_lock:
+            self.ws_app = ws_app
+        try:
+            ws_app.run_forever(ping_interval=None, ping_timeout=None)
+        finally:
+            self.connected_event.clear()
+            with self.ws_lock:
+                self.ws_app = None
+
+    def _on_open(self, ws: WebSocketApp) -> None:
+        self.logger.info("WebSocket connection established")
+        self.connected_event.set()
+        self._send_subscribe()
+
+    def _on_close(self, ws: WebSocketApp, status_code: Optional[int], msg: Optional[str]) -> None:
+        self.logger.warning("WebSocket closed: status=%s message=%s", status_code, msg)
+        self.connected_event.clear()
+
+    def _on_error(self, ws: WebSocketApp, error: Exception) -> None:
+        self.logger.error("WebSocket error: %s", error, exc_info=True)
+        self.connected_event.clear()
+
+    def _on_message(self, ws: WebSocketApp, message: str) -> None:
+        self.logger.debug("Received message: %s", message)
+        try:
+            payload = json.loads(message)
+        except json.JSONDecodeError:
+            self.logger.error("Invalid JSON received: %s", message)
+            return
+
+        destination = payload.get("destination")
+        status = payload.get("status")
+        if status and status != "OK":
+            self.logger.warning("Received non-OK status message: %s", payload)
+
+        if destination == "pong":
+            self.logger.debug("Received pong response")
+            return
+        if destination != "quote":
+            self.logger.debug("Ignoring non-quote message: %s", destination)
+            return
+
+        quote = payload.get("payload")
+        if not isinstance(quote, dict):
+            self.logger.warning("Quote payload malformed: %s", payload)
+            return
+
+        epic = quote.get("epic")
+        if not epic:
+            self.logger.warning("Quote payload without epic: %s", payload)
+            return
+
+        asset_id = self.asset_ids.get(epic)
+        if asset_id is None:
+            self.logger.error("No asset_id mapping for epic %s", epic)
+            return
+
+        epoch_ms = quote.get("timestamp")
+        if epoch_ms is None:
+            self.logger.warning("Quote payload missing timestamp: %s", payload)
+            return
+
+        try:
+            epoch_ms_int = int(epoch_ms)
+        except (TypeError, ValueError):
+            self.logger.warning("Invalid timestamp in payload: %s", payload)
+            return
+
+        ts = datetime.fromtimestamp(epoch_ms_int / 1000.0, tz=timezone.utc)
+        record = {
+            "asset_id": asset_id,
+            "timestamp": ts,
+            "symbol": epic,
+            "tipo": payload.get("destination") or "quote",
+            "precio_compra": _to_float(quote.get("bid")),
+            "cantidad_disponible_compra": _to_float(quote.get("bidQty")),
+            "precio_venta": _to_float(quote.get("ofr")),
+            "cantidad_disponible_venta": _to_float(quote.get("ofrQty")),
+            "epoch": epoch_ms_int,
+        }
+        self._persist_record(record)
+
+    def _send_subscribe(self) -> None:
+        if not self.tokens:
+            self.logger.error("Cannot subscribe without tokens")
+            return
+        subscribe_message = {
+            "destination": "marketData.subscribe",
+            "correlationId": f"subscribe-{int(time.time())}",
+            "cst": self.tokens["cst"],
+            "securityToken": self.tokens["securityToken"],
+            "payload": {"epics": self.config.target_epics},
+        }
+        self._send_json(subscribe_message)
+        self.logger.info("Subscription message sent for EPICs: %s", ", ".join(self.config.target_epics))
+
+    def _send_ping(self) -> None:
+        if not self.tokens:
+            return
+        ping_message = {
+            "destination": "ping",
+            "correlationId": f"ping-{int(time.time())}",
+            "cst": self.tokens["cst"],
+            "securityToken": self.tokens["securityToken"],
+        }
+        self._send_json(ping_message)
+        self.logger.info("Ping sent")
+
+    def _send_json(self, payload: Dict[str, object]) -> None:
+        message = json.dumps(payload)
+        with self.ws_lock:
+            ws = self.ws_app
+            if ws is None:
+                self.logger.debug("WebSocket not available for sending message")
+                return
+            try:
+                ws.send(message)
+            except Exception as exc:
+                self.logger.error("Failed to send message: %s", exc, exc_info=True)
+
+    def _ping_loop(self) -> None:
+        while not self.stop_event.is_set():
+            if not self.connected_event.wait(timeout=1):
+                continue
+            if self.stop_event.wait(timeout=self.config.ping_interval_seconds):
+                break
+            if not self.connected_event.is_set():
+                continue
+            self._send_ping()
+        self.logger.info("Ping thread terminated")
+
+    def _persist_record(self, record: Dict[str, object]) -> None:
+        columns = (
+            "asset_id",
+            "timestamp",
+            "symbol",
+            "tipo",
+            "precio_compra",
+            "cantidad_disponible_compra",
+            "precio_venta",
+            "cantidad_disponible_venta",
+            "epoch",
+        )
+        values = tuple(record[col] for col in columns)
+        insert_sql = f"""
+            INSERT INTO {self.config.table_name} ({', '.join(columns)})
+            VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+        """
+        try:
+            with self.db_conn.cursor() as cur:
+                cur.execute(insert_sql, values)
+            self.logger.info(
+                "Stored quote %s at %s (asset_id=%s)",
+                record["symbol"],
+                record["timestamp"].isoformat(),
+                record["asset_id"],
+            )
+        except Exception as exc:
+            self.logger.exception("Failed to persist record: %s", exc)
+
+    def stop(self) -> None:
+        self.stop_event.set()
+        self.connected_event.set()
+        with self.ws_lock:
+            if self.ws_app is not None:
+                try:
+                    self.ws_app.close()
+                except Exception:
+                    self.logger.exception("Error closing WebSocket")
+        if self.ping_thread.is_alive() and threading.current_thread() is not self.ping_thread:
+            self.ping_thread.join(timeout=5)
+        if self.db_conn:
+            try:
+                self.db_conn.close()
+            except Exception:
+                self.logger.exception("Error closing database connection")
+
+
+def _to_float(value: Optional[object]) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    load_dotenv(Path(".env"))
+    config = Config.from_env()
+    streamer = CapitalWebSocketStreamer(config)
+
+    def handle_signal(signum: int, frame) -> None:  # type: ignore[override]
+        streamer.logger.info("Signal %s received, shutting down", signum)
+        streamer.stop()
+
+    signal.signal(signal.SIGTERM, handle_signal)
+    signal.signal(signal.SIGINT, handle_signal)
+
+    try:
+        streamer.run()
+    finally:
+        streamer.stop()
+
+
+if __name__ == "__main__":
+    main()

--- a/streaming_eodhd.py
+++ b/streaming_eodhd.py
@@ -1,0 +1,555 @@
+"""EOD Historical Data WebSocket client for US equities trades and quotes."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import signal
+import sys
+from dataclasses import dataclass
+from datetime import datetime, time as dtime, timezone
+from typing import Dict, List, Optional
+
+import aiohttp
+from dotenv import load_dotenv
+from psycopg2.pool import SimpleConnectionPool
+
+load_dotenv()
+
+LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+LOGGER = logging.getLogger("EODHD_WS")
+LOGGER.setLevel(LOG_LEVEL)
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(
+    logging.Formatter(
+        json.dumps(
+            {
+                "ts": "%(asctime)s",
+                "level": "%(levelname)s",
+                "service": "EODHD_WS",
+                "module": "%(module)s",
+                "msg": "%(message)s",
+            }
+        )
+    )
+)
+if not LOGGER.handlers:
+    LOGGER.addHandler(handler)
+
+
+@dataclass(frozen=True)
+class SymbolMapping:
+    """Symbol mapping between local identifier and EODHD epic."""
+
+    local_symbol: str
+    remote_symbol: str
+    asset_id: int
+
+
+class SettingsError(RuntimeError):
+    """Raised when configuration is invalid."""
+
+
+@dataclass
+class Settings:
+    api_token: str
+    symbols_env: str
+    db_host: str
+    db_port: int
+    db_name: str
+    db_user: str
+    db_password: str
+    reconnect_delay: int = 5
+    heartbeat: int = 120
+    symbol_suffix: str = ".US"
+
+    @classmethod
+    def from_env(cls) -> "Settings":
+        missing = [
+            name
+            for name in (
+                "API_TOKEN",
+                "SYMBOLS",
+                "DB_HOST",
+                "DB_PORT",
+                "DB_NAME",
+                "DB_USER",
+                "DB_PASSWORD",
+            )
+            if not os.getenv(name)
+        ]
+        if missing:
+            raise SettingsError(
+                "Faltan variables de entorno obligatorias: " + ", ".join(missing)
+            )
+
+        reconnect_delay = int(os.getenv("RECONNECT_DELAY", "5"))
+        heartbeat = int(os.getenv("WS_HEARTBEAT_SECONDS", "120"))
+        suffix = os.getenv("EOD_SYMBOL_SUFFIX", ".US")
+
+        return cls(
+            api_token=os.environ["API_TOKEN"].strip(),
+            symbols_env=os.environ["SYMBOLS"].strip(),
+            db_host=os.environ["DB_HOST"].strip(),
+            db_port=int(os.environ["DB_PORT"].strip()),
+            db_name=os.environ["DB_NAME"].strip(),
+            db_user=os.environ["DB_USER"].strip(),
+            db_password=os.environ["DB_PASSWORD"].strip(),
+            reconnect_delay=reconnect_delay,
+            heartbeat=heartbeat,
+            symbol_suffix=suffix,
+        )
+
+
+def parse_symbol_mappings(raw: str, suffix: str) -> List[SymbolMapping]:
+    mappings: List[SymbolMapping] = []
+    seen_remote: set[str] = set()
+    for chunk in raw.split(","):
+        item = chunk.strip()
+        if not item:
+            continue
+        parts = [p.strip() for p in item.split(":") if p.strip()]
+        if len(parts) != 3:
+            raise SettingsError(
+                "Formato inválido en SYMBOLS. Esperado LOCAL:REMOTE:ASSET_ID"
+            )
+        local_symbol, remote_symbol, asset_id_raw = parts
+        try:
+            asset_id = int(asset_id_raw)
+        except ValueError as exc:  # pragma: no cover - validated manual input
+            raise SettingsError(f"asset_id inválido para {local_symbol}: {asset_id_raw}") from exc
+
+        if "." not in remote_symbol and suffix:
+            corrected_symbol = f"{remote_symbol}{suffix}"
+            LOGGER.warning(
+                "El símbolo %s no incluye mercado. Usando %s para suscripción",
+                remote_symbol,
+                corrected_symbol,
+            )
+            remote_symbol = corrected_symbol
+
+        if remote_symbol in seen_remote:
+            raise SettingsError(f"Símbolo remoto duplicado: {remote_symbol}")
+        seen_remote.add(remote_symbol)
+
+        mappings.append(SymbolMapping(local_symbol, remote_symbol, asset_id))
+    if not mappings:
+        raise SettingsError("No se configuraron símbolos para la suscripción")
+    return mappings
+
+
+class Database:
+    def __init__(self, settings: Settings) -> None:
+        self._pool = SimpleConnectionPool(
+            minconn=1,
+            maxconn=int(os.getenv("DB_POOL_MAX", "10")),
+            host=settings.db_host,
+            port=settings.db_port,
+            dbname=settings.db_name,
+            user=settings.db_user,
+            password=settings.db_password,
+        )
+        self._ensure_tables()
+
+    def close(self) -> None:
+        if self._pool:
+            self._pool.closeall()
+
+    def _ensure_tables(self) -> None:
+        create_trades = """
+        CREATE TABLE IF NOT EXISTS trades_real_time (
+            id BIGSERIAL PRIMARY KEY,
+            asset_id INTEGER NOT NULL,
+            symbol TEXT NOT NULL,
+            session TEXT NOT NULL,
+            price DOUBLE PRECISION,
+            size BIGINT,
+            condition_code INTEGER,
+            dark_pool BOOLEAN,
+            market_status TEXT,
+            event_timestamp TIMESTAMPTZ NOT NULL,
+            ingestion_ts TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        """
+        create_quotes = """
+        CREATE TABLE IF NOT EXISTS quotes_real_time (
+            id BIGSERIAL PRIMARY KEY,
+            asset_id INTEGER NOT NULL,
+            symbol TEXT NOT NULL,
+            session TEXT NOT NULL,
+            bid_price DOUBLE PRECISION,
+            ask_price DOUBLE PRECISION,
+            bid_size BIGINT,
+            ask_size BIGINT,
+            event_timestamp TIMESTAMPTZ NOT NULL,
+            ingestion_ts TIMESTAMPTZ NOT NULL DEFAULT NOW()
+        );
+        """
+        conn = self._pool.getconn()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(create_trades)
+                    cur.execute(create_quotes)
+        finally:
+            self._pool.putconn(conn)
+
+    def persist_trade(
+        self,
+        *,
+        asset_id: int,
+        symbol: str,
+        session: str,
+        price: float,
+        size: int,
+        condition_code: int,
+        dark_pool: bool,
+        market_status: str,
+        event_timestamp: datetime,
+    ) -> None:
+        conn = self._pool.getconn()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        INSERT INTO trades_real_time (
+                            asset_id, symbol, session, price, size, condition_code,
+                            dark_pool, market_status, event_timestamp, ingestion_ts
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, NOW())
+                        """,
+                        (
+                            asset_id,
+                            symbol,
+                            session,
+                            price,
+                            size,
+                            condition_code,
+                            dark_pool,
+                            market_status,
+                            event_timestamp,
+                        ),
+                    )
+        finally:
+            self._pool.putconn(conn)
+
+    def persist_quote(
+        self,
+        *,
+        asset_id: int,
+        symbol: str,
+        session: str,
+        bid_price: Optional[float],
+        ask_price: Optional[float],
+        bid_size: int,
+        ask_size: int,
+        event_timestamp: datetime,
+    ) -> None:
+        conn = self._pool.getconn()
+        try:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        """
+                        INSERT INTO quotes_real_time (
+                            asset_id, symbol, session, bid_price, ask_price,
+                            bid_size, ask_size, event_timestamp, ingestion_ts
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, NOW())
+                        """,
+                        (
+                            asset_id,
+                            symbol,
+                            session,
+                            bid_price,
+                            ask_price,
+                            bid_size,
+                            ask_size,
+                            event_timestamp,
+                        ),
+                    )
+        finally:
+            self._pool.putconn(conn)
+
+
+def market_session(now_utc: Optional[dtime] = None) -> str:
+    current = now_utc or datetime.now(timezone.utc).time()
+    if dtime(8, 0) <= current < dtime(13, 30):
+        return "pre-market"
+    if dtime(13, 30) <= current < dtime(20, 0):
+        return "market-time"
+    if dtime(20, 0) <= current < dtime(23, 59):
+        return "post-market"
+    return "overnight"
+
+
+def timestamp_from_ms(ms: Optional[int]) -> datetime:
+    if ms:
+        return datetime.fromtimestamp(ms / 1000, tz=timezone.utc)
+    return datetime.now(timezone.utc)
+
+
+class WebSocketWorker:
+    def __init__(
+        self,
+        *,
+        name: str,
+        url: str,
+        settings: Settings,
+        database: Database,
+        mappings: Dict[str, SymbolMapping],
+        payload_symbols: str,
+    ) -> None:
+        self.name = name
+        self.url = url
+        self.settings = settings
+        self.database = database
+        self.mappings = mappings
+        self.payload_symbols = payload_symbols
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._closing = asyncio.Event()
+
+    async def start(self) -> None:
+        while not self._closing.is_set():
+            try:
+                await self._run_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                LOGGER.error(
+                    "Error en cliente %s: %s. Reintentando en %ss",
+                    self.name,
+                    exc,
+                    self.settings.reconnect_delay,
+                    exc_info=True,
+                )
+            await asyncio.sleep(self.settings.reconnect_delay)
+
+    async def stop(self) -> None:
+        self._closing.set()
+        if self._session is not None:
+            await self._session.close()
+
+    async def _run_once(self) -> None:
+        payload = {
+            "action": "subscribe",
+            "symbols": self.payload_symbols,
+            "api_token": self.settings.api_token,
+        }
+        async with aiohttp.ClientSession() as session:
+            self._session = session
+            async with session.ws_connect(
+                self.url,
+                heartbeat=self.settings.heartbeat,
+                receive_timeout=self.settings.heartbeat + 30,
+            ) as ws:
+                LOGGER.info("Conectado a %s", self.name)
+                await ws.send_json(payload)
+                async for msg in ws:
+                    if msg.type == aiohttp.WSMsgType.TEXT:
+                        await self._handle_text(msg.data)
+                    elif msg.type == aiohttp.WSMsgType.ERROR:
+                        raise RuntimeError(f"WebSocket error: {ws.exception()}")
+                    elif msg.type == aiohttp.WSMsgType.CLOSED:
+                        LOGGER.warning("WebSocket %s cerrado por el servidor", self.name)
+                        break
+
+    async def _handle_text(self, raw: str) -> None:
+        try:
+            data = json.loads(raw)
+        except json.JSONDecodeError:
+            LOGGER.error("Mensaje no es JSON válido en %s: %s", self.name, raw)
+            return
+
+        if isinstance(data, dict) and "status" in data and "s" not in data:
+            status = data.get("status")
+            message = data.get("message", "")
+            status_text = str(status).upper()
+            if status_text not in {"OK", "200"}:
+                raise RuntimeError(f"Suscripción rechazada ({status}): {message}")
+            LOGGER.info("Respuesta de control %s: %s", self.name, message or status)
+            return
+
+        if isinstance(data, list):
+            for entry in data:
+                if isinstance(entry, dict):
+                    await self.process_payload(entry)
+            return
+
+        if not isinstance(data, dict):
+            LOGGER.debug("Mensaje ignorado en %s: %s", self.name, data)
+            return
+
+        await self.process_payload(data)
+
+    async def process_payload(self, data: Dict[str, object]) -> None:  # pragma: no cover - overwritten
+        raise NotImplementedError
+
+
+class TradesWorker(WebSocketWorker):
+    async def process_payload(self, data: Dict[str, object]) -> None:
+        symbol_remote = data.get("s")
+        price = data.get("p")
+        if not symbol_remote or price is None:
+            LOGGER.debug("Mensaje de trade ignorado: %s", data)
+            return
+        mapping = self.mappings.get(str(symbol_remote))
+        if not mapping:
+            LOGGER.warning("Trade recibido para símbolo no mapeado: %s", symbol_remote)
+            return
+
+        volume_raw = data.get("v", 0)
+        try:
+            size = int(volume_raw)
+        except (TypeError, ValueError):
+            size = 0
+
+        condition_raw = data.get("c")
+        condition_code = 0
+        if isinstance(condition_raw, list) and condition_raw:
+            try:
+                condition_code = int(condition_raw[0])
+            except (TypeError, ValueError):
+                condition_code = 0
+        elif condition_raw is not None:
+            try:
+                condition_code = int(condition_raw)
+            except (TypeError, ValueError):
+                condition_code = 0
+
+        dark_pool = bool(data.get("dp", False))
+        market_status = str(data.get("e", "unknown"))
+        event_ts = timestamp_from_ms(data.get("t"))
+
+        LOGGER.debug(
+            "Persistiendo trade %s %.4f x %s", mapping.local_symbol, float(price), size
+        )
+        await asyncio.to_thread(
+            self.database.persist_trade,
+            asset_id=mapping.asset_id,
+            symbol=mapping.local_symbol,
+            session=market_session(),
+            price=float(price),
+            size=size,
+            condition_code=condition_code,
+            dark_pool=dark_pool,
+            market_status=market_status,
+            event_timestamp=event_ts,
+        )
+
+
+class QuotesWorker(WebSocketWorker):
+    async def process_payload(self, data: Dict[str, object]) -> None:
+        symbol_remote = data.get("s")
+        if not symbol_remote:
+            LOGGER.debug("Mensaje de quote sin símbolo: %s", data)
+            return
+        mapping = self.mappings.get(str(symbol_remote))
+        if not mapping:
+            LOGGER.warning("Quote recibido para símbolo no mapeado: %s", symbol_remote)
+            return
+
+        bid_price = data.get("bp")
+        ask_price = data.get("ap")
+        bid_size_raw = data.get("bs", 0)
+        ask_size_raw = data.get("as", 0)
+        try:
+            bid_size = int(bid_size_raw)
+        except (TypeError, ValueError):
+            bid_size = 0
+        try:
+            ask_size = int(ask_size_raw)
+        except (TypeError, ValueError):
+            ask_size = 0
+
+        event_ts = timestamp_from_ms(data.get("t"))
+
+        LOGGER.debug(
+            "Persistiendo quote %s bid=%s ask=%s",
+            mapping.local_symbol,
+            bid_price,
+            ask_price,
+        )
+        await asyncio.to_thread(
+            self.database.persist_quote,
+            asset_id=mapping.asset_id,
+            symbol=mapping.local_symbol,
+            session=market_session(),
+            bid_price=float(bid_price) if bid_price is not None else None,
+            ask_price=float(ask_price) if ask_price is not None else None,
+            bid_size=bid_size,
+            ask_size=ask_size,
+            event_timestamp=event_ts,
+        )
+
+
+async def run(settings: Settings) -> None:
+    mappings_list = parse_symbol_mappings(settings.symbols_env, settings.symbol_suffix)
+    mappings = {m.remote_symbol: m for m in mappings_list}
+    payload_symbols = ",".join(m.remote_symbol for m in mappings_list)
+    LOGGER.info("Suscribiendo símbolos remotos: %s", payload_symbols)
+
+    database = Database(settings)
+
+    trades_url = f"wss://ws.eodhistoricaldata.com/ws/us?api_token={settings.api_token}"
+    quotes_url = f"wss://ws.eodhistoricaldata.com/ws/us-quote?api_token={settings.api_token}"
+
+    trades_worker = TradesWorker(
+        name="TRADES",
+        url=trades_url,
+        settings=settings,
+        database=database,
+        mappings=mappings,
+        payload_symbols=payload_symbols,
+    )
+    quotes_worker = QuotesWorker(
+        name="QUOTES",
+        url=quotes_url,
+        settings=settings,
+        database=database,
+        mappings=mappings,
+        payload_symbols=payload_symbols,
+    )
+
+    stop_event = asyncio.Event()
+
+    def _handle_signal(signame: str) -> None:
+        LOGGER.warning("Señal %s recibida. Cerrando...")
+        stop_event.set()
+
+    loop = asyncio.get_running_loop()
+    for signame in {"SIGTERM", "SIGINT"}:
+        if hasattr(signal, signame):
+            loop.add_signal_handler(getattr(signal, signame), _handle_signal, signame)
+
+    async def _stop_on_event() -> None:
+        await stop_event.wait()
+        await asyncio.gather(trades_worker.stop(), quotes_worker.stop())
+        database.close()
+
+    await asyncio.gather(
+        trades_worker.start(),
+        quotes_worker.start(),
+        _stop_on_event(),
+    )
+
+
+def main() -> None:
+    try:
+        settings = Settings.from_env()
+    except SettingsError as exc:
+        LOGGER.critical("Configuración inválida: %s", exc)
+        sys.exit(1)
+
+    try:
+        asyncio.run(run(settings))
+    except KeyboardInterrupt:
+        LOGGER.info("Proceso interrumpido por el usuario")
+    except Exception as exc:
+        LOGGER.critical("Fallo crítico: %s", exc, exc_info=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a dedicated EOD Historical Data websocket streamer that validates symbol formats, pools database connections, and stores trades/quotes safely
- auto-append the `.US` suffix when the configured remote symbols omit the market, preventing 403 subscription errors and logging server control messages before persisting
- document the new workflow in the README and declare aiohttp/websockets/dotenv dependencies

## Testing
- python -m compileall streaming_eodhd.py streaming_capital.py

------
https://chatgpt.com/codex/tasks/task_e_68cbba4128e88331b18f0bc2d2117884